### PR TITLE
Allow user-specified timeouts for "trusted" builds

### DIFF
--- a/etc/buildkite-agent/hooks/command
+++ b/etc/buildkite-agent/hooks/command
@@ -64,6 +64,7 @@ do
     build_env+=( "--env=${var#SECRET_}=${!var}" )
 done
 
+# Volumes
 declare -r tmp_size=200000000 # 200MB
 volumes=(
     "--tmpfs=/tmp:rw,exec,nosuid,size=$tmp_size"
@@ -80,10 +81,12 @@ fi
 uid="$(id -u buildkite-builder)"
 gid="$(id -g buildkite-builder)"
 
+set +e
 timeout \
-    --kill-after=1h \
+    --kill-after="$((BUILD_TIMEOUT_MINUTES + 10))m" \
     --signal=TERM \
-    50m \
+    --verbose \
+    "${BUILD_TIMEOUT_MINUTES}m" \
     docker run --tty --rm \
         --name="build-${BUILDKITE_BUILD_ID}-${BUILDKITE_STEP_ID}" \
         --read-only \
@@ -96,3 +99,11 @@ timeout \
         "${build_env[@]}" \
         "${DOCKER_IMAGE}"  \
         /bin/sh -c "${BUILDKITE_COMMAND}"
+
+if [[ $? == 124 ]]
+then
+    echo
+    echo "The job timed out after ${BUILD_TIMEOUT_MINUTES} minutes!"
+    echo
+fi
+exit $?

--- a/etc/buildkite-agent/hooks/environment
+++ b/etc/buildkite-agent/hooks/environment
@@ -2,6 +2,10 @@
 set -eou pipefail
 IFS=$'\n\t'
 
+declare -ri MIN_TIMEOUT_MINUTES=50
+declare -ri MAX_TIMEOUT_MINUTES=240
+declare -i timeout_minutes=$MIN_TIMEOUT_MINUTES
+
 declare -r cache_volume_prefix="cache_${BUILDKITE_AGENT_NAME}_${BUILDKITE_ORGANIZATION_SLUG}_${BUILDKITE_PIPELINE_SLUG}"
 declare -r master_cache_volume="${cache_volume_prefix}_${BUILDKITE_PIPELINE_DEFAULT_BRANCH}"
 
@@ -43,6 +47,12 @@ then
     fi
 
     export SECRET_GOOGLE_APPLICATION_CREDENTIALS=/etc/gce/cred.json
+
+    # "Trusted" builds may bump the timeout
+    if [[ "${BUILDKITE_TIMEOUT}" != "false" ]]
+    then
+        timeout_minutes="$((BUILDKITE_TIMEOUT > MAX_TIMEOUT_MINUTES ? MAX_TIMEOUT_MINUTES : BUILDKITE_TIMEOUT))"
+    fi
 else
     # Use kata-containers for isolation
     export DOCKER_RUNTIME=kata-containers
@@ -50,3 +60,5 @@ else
     # end of the build
     export DOCKER_CACHE_MOUNT="type=volume,dst=/cache,volume-driver=zockervols,volume-opt=from=${master_cache_volume},volume-opt=quota=1GiB"
 fi
+
+export BUILD_TIMEOUT_MINUTES=$timeout_minutes


### PR DESCRIPTION
i.e. the `timeout_in_minutes` step attribute