### PR TITLE
Use mapfile instead of read -ra when evaluating prunable cache volumes.

### DIFF
--- a/linux/etc/systemd/system/docker-volume-prune.sh
+++ b/linux/etc/systemd/system/docker-volume-prune.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
-yesterday="$(date --utc --date='yesterday' +'%Y-%m-%dT00:00:00Z')"
+expiration_date="$(date --utc --date='1 week ago' +'%Y-%m-%dT00:00:00Z')"
 
 mapfile -t prune < <(
     docker volume ls --filter=label=build_cache --format='{{ .Name }}' \
     | xargs --no-run-if-empty docker volume inspect \
-    | jq -rM --arg date "$yesterday" \
+    | jq -rM --arg date "$expiration_date" \
         '. | map(select(.Mountpoint == "none")) | map(select(.CreatedAt < $date)) | map(.Name) | .[]'
 )
 

--- a/linux/etc/systemd/system/docker-volume-prune.sh
+++ b/linux/etc/systemd/system/docker-volume-prune.sh
@@ -3,19 +3,21 @@ set -eou pipefail
 
 yesterday="$(date --utc --date='yesterday' +'%Y-%m-%dT00:00:00Z')"
 
-read -ra prune <<< "$(
+mapfile -t prune < <(
     docker volume ls --filter=label=build_cache --format='{{ .Name }}' \
     | xargs --no-run-if-empty docker volume inspect \
     | jq -rM --arg date "$yesterday" \
         '. | map(select(.Mountpoint == "none")) | map(select(.CreatedAt < $date)) | map(.Name) | .[]'
-)"
+)
 
 if [ ${#prune[@]} -gt 0 ]
 then
-    set -x
+    set +e
     for vol in "${prune[@]}"
     do
+        set -x
         docker volume rm "$vol"
+        set +x
     done
 else
     echo "No prunable docker volumes found."


### PR DESCRIPTION
shellcheck did recommend read at some point, but that doesn't seem to do
the right thing.

Fixes #30