### PR TITLE
Secrets only for trusted builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ The build agent probes for a file `.buildkite/secrets.yaml` in the source
 checkout, and if it exists, attempts to decrypt it using [`sops`][sops] in
 "dotenv" format into a file `.secrets` at the root of the source checkout.
 
+Secrets are not available to pull requests builds.
+
 Repositories making using of this feature must:
 
 1. Create a new symmetric key in the GCP KMS.

--- a/linux/etc/buildkite-agent/hooks/environment
+++ b/linux/etc/buildkite-agent/hooks/environment
@@ -21,8 +21,7 @@ docker volume create \
     --driver=zockervols \
     --opt="quota=${CACHE_QUOTA_GiB}GiB" \
     --opt="exec=on" \
-    --quiet
-    "$master_cache_volume"
+    "$master_cache_volume" >/dev/null
 echo "Using master cache volume ${master_cache_volume}"
 
 # [Note on CI and organizations]

--- a/linux/etc/buildkite-agent/hooks/post-checkout
+++ b/linux/etc/buildkite-agent/hooks/post-checkout
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
-pushd "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+pushd "${BUILDKITE_BUILD_CHECKOUT_PATH}" >/dev/null
 
-if [[ -r .buildkite/secrets.yaml ]]
+if [[ -r .buildkite/secrets.yaml && ( "${BUILDKITE_PULL_REQUEST_REPO}" == "" || "${BUILDKITE_PULL_REQUEST_REPO}" =~ $TRUSTED_UPSTREAMS_REGEX ) ]];
 then
+    echo "Writing secrets to ./.secrets"
+
     GOOGLE_APPLICATION_CREDENTIALS=/etc/gce/cred.json \
       sops \
       --output-type dotenv \
@@ -12,6 +14,6 @@ then
       --decrypt .buildkite/secrets.yaml
 fi
 
-sudo chown -R buildkite-builder .
+popd >/dev/null
 
-popd
+sudo chown -R buildkite-builder "${BUILDKITE_BUILD_CHECKOUT_PATH}"


### PR DESCRIPTION
* Per repo secrets are only available for trusted builds
* Fix a couple of things that did not work