### PR TITLE
Clarify build image docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,13 @@ branch builds also know to use the master cache.
 ### Building docker images
 
 Linux builds run inside docker containers. The image to use for the build step
-is specified via the `DOCKER_IMAGE` environment variable of the step. The image
-may also be built on the build agent itself, before executing the build step. To
-do this, specify an environment variable `DOCKER_FILE` which points to a
-`Dockerfile` relative to the repository root.
+is specified via the `DOCKER_IMAGE` environment variable of the step.
 
-Note that `DOCKER_IMAGE` takes precedence over `DOCKER_FILE` -- if `docker pull
-$DOCKER_IMAGE` succeeds, no new image is built.
+If the build agent fails to pull `DOCKER_IMAGE` it uses `DOCKER_FILE` to build
+the image locally. The image is also pushed, using the image name
+of`${DOCKER_IMAGE}` and the tag `${BUILDKITE_COMMIT}`.
 
 Only `DOCKER_IMAGE`s from the `gcr.io/opensourcecoin` repository are permitted.
-Images built by the agent are pushed to `gcr.io/opensourcecoin/${BUILDKITE_PIPELINE_SLUG}-build:${BUILDKITE_COMMIT}`
-if no `DOCKER_IMAGE` is given, and to `${DOCKER_IMAGE}:${BUILDKITE_COMMIT}`
-otherwise.
 
 ```yaml
 steps:

--- a/linux/etc/buildkite-agent/hooks/command
+++ b/linux/etc/buildkite-agent/hooks/command
@@ -178,10 +178,9 @@ then
     if [[ -n ${DOCKER_FILE:-} ]]
     then
         # Re-tag DOCKER_IMAGE with current commit
-        : "${DOCKER_IMAGE:=gcr.io/opensourcecoin/${BUILDKITE_PIPELINE_SLUG}-build}"
         : "${DOCKER_IMAGE%%:*}"
-        : "${_%%@*}"
-        DOCKER_IMAGE="${_}:${BUILDKITE_COMMIT}"
+        : "${DOCKER_IMAGE%%@*}"
+        DOCKER_IMAGE="${DOCKER_IMAGE}:${BUILDKITE_COMMIT}"
 
         build_docker_image \
             "$DOCKER_IMAGE" \


### PR DESCRIPTION
We clarify the behavior of building the base images.

* We remove the reference to the default. Having `DOCKER_IMAGE` set is a requirement because of `set -u`. We also remove this from the code.
* We clarify that the pushed image uses the *base name* of `DOCKER_IMAGE`.
* For more clarify we use `${DOCKER_IMAGE}` instead of `${_}` in the code.