### PR TITLE
Store build artifacts in our own GCS bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,20 @@ Repositories making using of this feature must:
 
 [sops]: https://github.com/mozilla/sops
 
+## Build artifacts
+
+Artifacts uploaded via the [buildkite agent](https://buildkite.com/docs/pipelines/artifacts)
+are stored in a publicly readable Monadic-managed GCS bucket.
+
+Artifacts uploaded by a `master` (that is, `$BUILDKITE_PIPELINE_DEFAULT_BRANCH`)
+builds will have a predictable URL, e.g.:
+
+`https://builds.radicle.xyz/radicle-registry/master/$BUILDKITE_COMMIT/$ARTIFACT_PATH`
+
+All other artifacts are scoped by `$BUILDKITE_JOB_ID`, and best discovered
+through the Buildkite UI or API. E.g.:
+
+`https://builds.radicle.xyz/radicle-registry/b2d9d6fd-cc6a-4c44-90e4-b07b5c50ee4c/$ARTIFACT_PATH`
 
 ## macOS build agents
 

--- a/linux/etc/buildkite-agent/hooks/environment
+++ b/linux/etc/buildkite-agent/hooks/environment
@@ -98,3 +98,22 @@ else
 fi
 
 export TIMEOUT_MINUTES=$timeout_minutes
+
+# Artifacts
+#
+# We're storing artifacts in our own GCS bucket in order to get predictable
+# download URLs. However, in order to not having to deal with sanitising branch
+# names, this applies only to `master` (that is,
+# BUILDKITE_PIPELINE_DEFAULT_BRANCH) builds. All other branches are scoped by
+# BUILDKITE_JOB_ID, as is the default.
+#
+# Note that artifacts can be overwritten when triggering a rebuild. This is no
+# different from managed artifact storage.
+#
+if [[ "${BUILDKITE_BRANCH}" == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]]
+then
+    declare -r artifact_scope="${BUILDKITE_PIPELINE_DEFAULT_BRANCH}/${BUILDKITE_COMMIT}"
+else
+    declare -r artifact_scope="$BUILDKITE_JOB_ID"
+fi
+export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="gs://builds.radicle.xyz/${BUILDKITE_PIPELINE_SLUG}/${artifact_scope}"

--- a/linux/etc/systemd/system/buildkite-agent@.service.d/local.conf
+++ b/linux/etc/systemd/system/buildkite-agent@.service.d/local.conf
@@ -1,2 +1,3 @@
 [Service]
+Environment=BUILDKITE_GS_APPLICATION_CREDENTIALS=/etc/gce/cred.json
 EnvironmentFile=/etc/buildkite-agent/env


### PR DESCRIPTION
This provides a convenient way to publish build artifacts which do not require a package index (such as .deb packages).

_**Note**: the certificate DNS entry doesn't seem to be propagated yet, which also prevents TLS certificate provisioning. Use `https://storage.googleapis.com/builds.radicle.xyz` in the meantime.`_ 