### PR TITLE
Work around kata-containers shared executables bug

### DIFF
--- a/linux/bootstrap.sh
+++ b/linux/bootstrap.sh
@@ -46,6 +46,12 @@ apt_packages() {
         jq \
         sops \
         zockervols
+
+    # Unfortunately, the debian tini is dynamically linked. Make a copy of a
+    # statically linked tini for kata-containers
+    #
+    # See: https://github.com/kata-containers/runtime/issues/1901
+    cp /usr/bin/docker-init /usr/bin/kata-init
 }
 
 zfs_exists() {

--- a/linux/etc/buildkite-agent/hooks/command
+++ b/linux/etc/buildkite-agent/hooks/command
@@ -196,25 +196,51 @@ then
     fi
 fi
 
+run_args=(
+    "--name=build-${BUILDKITE_BUILD_ID}-${BUILDKITE_STEP_ID}"
+    '--tty'
+    '--rm'
+    '--read-only'
+    "--user=${uid}:${gid}"
+    '--cap-drop=ALL'
+    '--security-opts=no-new-privileges'
+    '--workdir=/build'
+)
+
+run_cmd="/bin/sh -ec"
+
+: "${DOCKER_RUNTIME:-runc}"
+
+# kata-containers segfault when sharing executables with the host OS.
+#
+# This is particularly annoying with --init: if a runc container is using tini
+# (/usr/bin/docker-init) currently, no kata-containers container can run.
+# Curiously, sharing a copy of tini amongst ONLY kata-containers seems to work.
+#
+# See: https://github.com/kata-containers/runtime/issues/1901
+if [[ "${DOCKER_RUNTIME}" == "kata-containers" ]]
+then
+    volumes+=("--mount=type=bind,src=/usr/bin/kata-init,dst=/tini")
+    run_cmd="/tini -sg -- ${run_cmd}"
+else
+    run_args+=('--init')
+fi
+
+# Must not quote run_cmd
+# shellcheck disable=SC2086
 timeout \
     --kill-after="$((TIMEOUT_MINUTES + 10))m" \
     --signal=TERM \
     --verbose \
     "${TIMEOUT_MINUTES}m" \
-    docker run --tty --rm \
-        --name="build-${BUILDKITE_BUILD_ID}-${BUILDKITE_STEP_ID}" \
-        --init \
-        --read-only \
-        --user="${uid}:${gid}" \
-        --cap-drop=ALL \
-        --security-opt=no-new-privileges \
-        --runtime="${DOCKER_RUNTIME:-runc}" \
-        "${volumes[@]}" \
-        --workdir=/build \
-        --entrypoint='' \
+    docker run \
+        "${run_args[@]}" \
         "${build_env[@]}" \
-        "${DOCKER_IMAGE}"  \
-        /bin/sh -e -c "${BUILDKITE_COMMAND}"
+        "${volumes[@]}" \
+        --entrypoint='' \
+        --runtime="${DOCKER_RUNTIME}" \
+        "${DOCKER_IMAGE}" \
+        ${run_cmd} "${BUILDKITE_COMMAND}"
 
 # If the step was to prepare a docker image build, run it now
 if [[ -n ${STEP_DOCKER_FILE:-} ]]


### PR DESCRIPTION
kata-containers segfault when sharing executables with the host OS.

This is particularly annoying with --init: if a runc container is using
tini (/usr/bin/docker-init) currently, no kata-containers container can
run. Curiously, sharing a copy of tini amongst ONLY kata-containers
seems to work.

See: https://github.com/kata-containers/runtime/issues/1901